### PR TITLE
fix build

### DIFF
--- a/kotlin-js-common/pom.xml
+++ b/kotlin-js-common/pom.xml
@@ -57,7 +57,7 @@
                             <goal>js</goal>
                         </goals>
                         <configuration>
-                            <outputFile>${project.build.outputDirectory}/../../js/${project.artifactId}.js</outputFile>
+                            <outputFile>${project.build.outputDirectory}/${project.artifactId}.js</outputFile>
                             <metaInfo>true</metaInfo>
                         </configuration>
                     </execution>
@@ -65,27 +65,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.jetbrains.kotlin</groupId>
-                                    <artifactId>kotlin-js-library</artifactId>
-                                    <version>${kotlin.version}</version>
-                                    <outputDirectory>${project.build.outputDirectory}/../../js</outputDirectory>
-                                    <includes>*.js</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin}</version>
+                <configuration>
+                    <forceCreation>true</forceCreation>
+                    <includes>
+                        <include>*.js</include>
+                    </includes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/kotlin-js-example/pom.xml
+++ b/kotlin-js-example/pom.xml
@@ -62,7 +62,7 @@
                             <goal>js</goal>
                         </goals>
                         <configuration>
-                            <outputFile>${project.build.outputDirectory}/../../js/${project.artifactId}.js</outputFile>
+                            <outputFile>${project.build.outputDirectory}/${project.artifactId}.js</outputFile>
                             <metaInfo>true</metaInfo>
                         </configuration>
                     </execution>
@@ -70,27 +70,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.jetbrains.kotlin</groupId>
-                                    <artifactId>kotlin-js-library</artifactId>
-                                    <version>${kotlin.version}</version>
-                                    <outputDirectory>${project.build.outputDirectory}/../../js</outputDirectory>
-                                    <includes>*.js</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin}</version>
+                <configuration>
+                    <forceCreation>true</forceCreation>
+                    <includes>
+                        <include>*.js</include>
+                    </includes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/kotlin-webapp/pom.xml
+++ b/kotlin-webapp/pom.xml
@@ -15,22 +15,39 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.7</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-kotlin-js</id>
-                        <phase>process-resources</phase>
+                        <id>unpack</id>
+                        <phase>compile</phase>
                         <goals>
-                            <goal>copy-resources</goal>
+                            <goal>unpack</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/kotlin-js-resources</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>../kotlin-js-example/js</directory>
-                                </resource>
-                            </resources>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jetbrains.kotlin</groupId>
+                                    <artifactId>kotlin-js-library</artifactId>
+                                    <version>${kotlin.version}</version>
+                                    <outputDirectory>${project.build.directory}/kotlin-js-resources</outputDirectory>
+                                    <includes>*.js</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>no.logiq.kotlin.javascript</groupId>
+                                    <artifactId>kotlin-js-common</artifactId>
+                                    <version>1.0-SNAPSHOT</version>
+                                    <outputDirectory>${project.build.directory}/kotlin-js-resources</outputDirectory>
+                                    <includes>*.js</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>no.logiq.kotlin.javascript</groupId>
+                                    <artifactId>kotlin-js-example</artifactId>
+                                    <version>1.0-SNAPSHOT</version>
+                                    <outputDirectory>${project.build.directory}/kotlin-js-resources</outputDirectory>
+                                    <includes>*.js</includes>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <version.jetty.plugin>9.2.10.v20150310</version.jetty.plugin>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.jar.plugin>2.6</maven.jar.plugin>
 
         <kotlin.version>0.12.200</kotlin.version>
     </properties>


### PR DESCRIPTION
Main changes:
- kotlin-js-common-1.0-SNAPSHOT.jar now contains kotlin-js-common.js and kotlin-js-common.meta.js
- kotlin-js-example-1.0-SNAPSHOT.jar now contains kotlin-js-example.js and kotlin-js-example.meta.js 
- in kotlin-webapp all JS files from kotlin-js-library, kotlin-js-common and kotlin-js-example are unpacked to kotlin-js-resources directory
